### PR TITLE
Update example configuration to use `rev` instead of `sha`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this to your `.pre-commit-config.yaml`:
 
 ```yaml
 -   repo: https://github.com/pre-commit/mirrors-isort
-    sha: ''  # Use the sha / tag you want to point at
+    rev: ''  # Use the revision sha / tag you want to point at
     hooks:
     -   id: isort
 ```


### PR DESCRIPTION
The [pre-commit documentation indicates](https://pre-commit.com/#pre-commit-configyaml---repos) `rev` is intended to replace `sha` as the config key to specify the revision of the hook to use. This change brings the example configuration in this repo inline with this change.