### PR TITLE
Document how to get isort to use requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,21 @@ Add this to your `.pre-commit-config.yaml`:
 
 `isort` isn't always the best at classifying imports.
 
-You may find [seed-isort-config](https://github.com/asottile/seed-isort-config)
-useful!
+As of 4.3.5, `isort` now supports reading from project metadata in
+order to identify which imports are third-party. To enable this, add
+the requirements mentioned in
+https://github.com/timothycrosley/isort/blob/develop/pyproject.toml#L39
+for the appropriate metadata format you want. For example, for
+`requirements.txt` support:
+
+```yaml
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: ''  # Use the revision sha / tag you want to point at
+    hooks:
+    -   id: isort
+        additional_dependencies: [pipreqs, pip-api]
+```
+
+You may also find
+[seed-isort-config](https://github.com/asottile/seed-isort-config)
+useful for the same purpose.


### PR DESCRIPTION
In https://github.com/timothycrosley/isort/releases/tag/4.3.5, `isort` gained the ability to automatically detect the set of third-party libraries from reading `requirements.txt` files (and others) (see https://github.com/timothycrosley/isort/pull/715/files). This functionality is pretty nice -- nicer than maintaining `known_third_party` in a Git repository. It can be turned on by installing `isort` with additional dependencies. However, in #8 it was explained that the preferred way for these dependencies to be installed is manually by listing them alongside the hook. Since this is the officially-sanctioned approach, document it explicitly. This isn't great because it means each user needs to track `isort` dependencies, but I think it's nicer to use this functionality than `seed-isort-config`.

Note that the example given doesn't work today because of https://github.com/di/pip-api/issues/42, but hopefully this will resolve itself over time.