### PR TITLE
Deprecate this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+This mirror repository is deprecated, use [isort] directly.
+
+[isort]: https://github.com/timothycrosley/isort
+
 isort mirror
 ============
 


### PR DESCRIPTION
Per
https://github.com/pre-commit/mirrors-isort/pull/11#issuecomment-545239524,
this project can be deprecated in favor of using the upstream isort
hook definition.